### PR TITLE
Add MIT license to typewriter

### DIFF
--- a/typewriter/Cargo.toml
+++ b/typewriter/Cargo.toml
@@ -3,6 +3,7 @@ name = "typewriter"
 version = "0.1.0"
 authors = ["Robert Lord <robert@lord.io>"]
 edition = "2018"
+license = "MIT"
 
 [dependencies]
 rusttype = "0.8.0"

--- a/typewriter/license.md
+++ b/typewriter/license.md
@@ -1,0 +1,7 @@
+Copyright 2019 Robert Lord
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
I assume you wanted a license on typewriter? Feel free to just add an MIT license to the root with your name on it instead.