### PR TITLE
[Bug fix] Change unwrap_or to unwrap_or_else

### DIFF
--- a/chunker/src/main.rs
+++ b/chunker/src/main.rs
@@ -56,7 +56,7 @@ fn print_progress(percent: f64) {
 fn main() -> Result<(), Error> {
     let args = Args::from_args();
 
-    let serial_device = args.serial_device.unwrap_or({
+    let serial_device = args.serial_device.unwrap_or_else(||{
         let devs: Vec<String> = std::fs::read_dir("/dev/")
             .unwrap()
             .filter_map(|e| {


### PR DESCRIPTION
Similar to this PR (https://github.com/rust-lang/rust/pull/55014).

In `unwrap_or` the fallback value is evaluated before `unwrap_or` is called. Which means even though a serial_device arg was provided
```
./target/debug/chunker ~/plot_file.hpgl /dev/tty.usbserial-1410
```

The program still failed

```
detected multiple serial devices: [
    "/dev/tty.usbserial",
    "/dev/tty.usbserial-1410",
], please specify only one!
```

This PR switches the `unwrap_or` call to `unwrap_or_else`. Which will only evaluate the fallback block in the `else` case.